### PR TITLE
Add CI build test for Linux and Mac OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: cpp
+
+sudo: required
+dist: trusty
+
+os:
+    - linux
+    - osx
+
+compiler:
+    - gcc
+    - clang
+
+before_script:
+    - cd ch2
+    - mkdir build
+    - cd build
+    - cmake ..
+
+script:
+    - make


### PR DESCRIPTION
- [x]  Added .travis.yml for CI build test of Chapter 2 under Linux and Mac OS X.